### PR TITLE
Make module build against newer kernels, and make it able to be compiled directly on arm devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,16 @@
 #ccflags-y+=-D CTRACER_ON
 obj-m += ubq_core.o
 
-KERNELDIR ?= /home/ben64/Documents/eads/projects/2015/usb/beagleboard/linux
+KERNELDIR ?= /lib/modules/$(shell uname -r)/build
 EXTRA_CFLAGS += -g -fms-extensions
+CROSS_COMPILE ?= 
 
 all:	modules
 
 ubq_core-y := core.o gadget.o driver.o com.o com_udp.o debug.o debug_usb.o common.o msg.o
 
 modules:
-	$(MAKE) ARCH=arm CROSS_COMPILE=arm-linux-gnueabi- -C $(KERNELDIR) M=$$PWD modules
+	$(MAKE) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) -C $(KERNELDIR) M=$$PWD modules
 
 modules_install:
 	$(MAKE) -C $(KERNELDIR) M=$$PWD modules_install

--- a/com_udp.c
+++ b/com_udp.c
@@ -196,7 +196,13 @@ import_single_range(int rw, void __user *buf, size_t len,
 {
    if (len > MAX_RW_COUNT)
       len = MAX_RW_COUNT;
+
+   // Type argument dropped in 5.0
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
    if (unlikely(!access_ok(!rw, buf, len)))
+#else
+   if (unlikely(!access_ok(buf, len)))
+#endif
       return -EFAULT;
 
    iov->iov_base = buf;
@@ -248,7 +254,12 @@ raw_recv(udp_state_t *state, unsigned char *addr, size_t len)
    slog(state,DBG,"READING DATA");
    oldfs = get_fs();
    set_fs(KERNEL_DS);
-   size = sock_recvmsg(sock,&msg,len,msg.msg_flags);
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,7,1)
+   size = sock_recvmsg(sock, &msg, len, msg.msg_flags);
+#else
+   size = sock_recvmsg(sock, &msg, msg.msg_flags);
+#endif
    set_fs(oldfs);
 
    state->clientaddr = *(struct sockaddr_in *)msg.msg_name;

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,8 @@
+MAKE="make KERNELDIR=/lib/modules/${kernelver}/build"
+CLEAN="make clean"
+BUILT_MODULE_NAME=ubq_core
+BUILT_MODULE_LOCATION=.
+PACKAGE_NAME=usbq_core
+PACKAGE_VERSION=1.1
+REMAKE_INITRD=no
+DEST_MODULE_LOCATION=/extra


### PR DESCRIPTION
I added `#if` statements to check against kernel version in a few places, because certain functions had arguments removed in newer kernel versions. Also, I made `CROSS_COMPILE` in the makefile default to empty and made the `KERNELDIR` variable default to `/lib/modules/KERNEL VERSION/build` to make it so you can build with just `make` provided you have the correct linux headers package installed.